### PR TITLE
[#1] Support working-directory param in setup-node action

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -33,6 +33,11 @@ inputs:
     required: false
     default: 'yes'
 
+  nvmrc-custom-dir:
+    description: Directory within the github.workspace directory where to find the .nvmrc file (for the setup-node action).
+    required: false
+    default: ''
+
   npm-ci-flags:
     description: Additional arguments for the 'npm ci' command.
     required: false
@@ -107,7 +112,7 @@ runs:
     - uses: actions/setup-node@v3
       if: ${{ inputs.setup-node == 'yes' }}
       with:
-        node-version-file: '.nvmrc'
+        node-version-file: ${{ inputs.nvmrc-custom-dir && format('{0}/{1}', inputs.nvmrc-custom-dir, '.nvmrc') || '.nvmrc' }}
 
     - name: Build frontend
       if: ${{ inputs.setup-node == 'yes' }}


### PR DESCRIPTION
Fixes #1

There is an issue in the setup-node action to be able to specify the working dir: https://github.com/actions/setup-node/issues/706