### PR TITLE
Pin actions to commit hashes

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -94,7 +94,7 @@ runs:
         echo "requirements_dir_prefix=${prefix}" >> $GITHUB_OUTPUT
       shell: bash
 
-    - uses: actions/setup-python@v5
+    - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       id: setup_python
       with:
         python-version: ${{ inputs.python-version }}
@@ -118,7 +118,7 @@ runs:
 
     - name: (Restore) uv cache
       id: uv-cache-restore
-      uses: actions/cache/restore@v4
+      uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       with:
         key: ${{ steps.setup_uv.outputs.cache_restore_key }}-${{ hashFiles(steps.setup_uv.outputs.cache_dependency_path) }}
         restore-keys: |
@@ -134,9 +134,10 @@ runs:
       working-directory: ${{ inputs.working-directory }}
 
     # TODO: enable cache
-    - uses: actions/setup-node@v4
+    - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       if: ${{ inputs.setup-node == 'yes' }}
       with:
+        package-manager-cache: 'false'
         node-version-file: ${{ inputs.nvmrc-custom-dir && format('{0}/{1}', inputs.nvmrc-custom-dir, '.nvmrc') || '.nvmrc' }}
 
     - name: Build frontend
@@ -150,8 +151,7 @@ runs:
     - name: Save uv cache
       id: uv-cache-save
       if: always() && steps.uv-cache-restore.outputs.cache-hit != 'true'
-      uses: actions/cache/save@v4
+      uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       with:
         key: ${{ steps.setup_uv.outputs.cache_restore_key }}-${{ hashFiles(steps.setup_uv.outputs.cache_dependency_path) }}
         path: ${{ steps.setup_uv.outputs.uv_cache_dir }}
-

--- a/action.yml
+++ b/action.yml
@@ -82,48 +82,13 @@ runs:
       shell: bash
       working-directory: ${{ inputs.working-directory }}
 
-    - name: Calculate requirements path
-      id: requirements_path
-      run: |
-        if [[ "${{ inputs.working-directory }}" ]]
-        then
-          prefix=${{ inputs.working-directory }}/
-        else
-          prefix=''
-        fi
-        echo "requirements_dir_prefix=${prefix}" >> $GITHUB_OUTPUT
-      shell: bash
-
-    - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
-      id: setup_python
+    - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+      id: setup-uv
       with:
         python-version: ${{ inputs.python-version }}
-
-    - name: Install uv (pip alternative)
-      id: setup_uv
-      # Docs: https://github.com/astral-sh/uv?tab=readme-ov-file#getting-started
-      run: |
-        pip install uv
-        # calculate cache parameters
-
-        cache_dependency_path="${{ steps.requirements_path.outputs.requirements_dir_prefix }}requirements/*.txt"
-
-        ubuntu_version=$(lsb_release -rs)
-        restore_key="uv-${{ runner.os }}-Ubuntu-${ubuntu_version}-python-${{ steps.setup_python.outputs.python-version }}"
-
-        echo "uv_cache_dir=$(uv cache dir)" >> "$GITHUB_OUTPUT"
-        echo "cache_dependency_path=${cache_dependency_path}" >> "$GITHUB_OUTPUT"
-        echo "cache_restore_key=${restore_key}" >> "$GITHUB_OUTPUT"
-      shell: bash
-
-    - name: (Restore) uv cache
-      id: uv-cache-restore
-      uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-      with:
-        key: ${{ steps.setup_uv.outputs.cache_restore_key }}-${{ hashFiles(steps.setup_uv.outputs.cache_dependency_path) }}
-        restore-keys: |
-          ${{ steps.setup_uv.outputs.cache_restore_key }}-
-        path: ${{ steps.setup_uv.outputs.uv_cache_dir }}
+        working-directory: ${{ inputs.working-directory }}
+        # Disable cashing on the default branch and tag builds
+        enable-cache: "${{ !(github.ref_name == github.event.repository.default_branch || startsWith(github.ref, 'refs/tags/')) }}"
 
     - name: Install backend dependencies
       run: |
@@ -133,7 +98,6 @@ runs:
       shell: bash
       working-directory: ${{ inputs.working-directory }}
 
-    # TODO: enable cache
     - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       if: ${{ inputs.setup-node == 'yes' }}
       with:
@@ -147,11 +111,3 @@ runs:
         npm run build
       shell: bash
       working-directory: ${{ inputs.working-directory }}
-
-    - name: Save uv cache
-      id: uv-cache-save
-      if: always() && steps.uv-cache-restore.outputs.cache-hit != 'true'
-      uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-      with:
-        key: ${{ steps.setup_uv.outputs.cache_restore_key }}-${{ hashFiles(steps.setup_uv.outputs.cache_dependency_path) }}
-        path: ${{ steps.setup_uv.outputs.uv_cache_dir }}


### PR DESCRIPTION
Using actions/cache is generally flagged as a possible cache-poisoning vulnerability by zizmor, but I think it should be fine here.

If I understand it correctly, the installed packages are cached with the requirements files hashed in the key. So the next time these exact requirements should be installed, we can fetch them from the cache. If they cannot be found, the last cache hit for ANY requirements files is returned, and the difference in package versions are installed with `uv pip install ...`. This means the required package versions will always be installed, and (possible) outdated/malicious packages will not be used. It will just happen more quickly because most of the packages are resolved already.