### PR TITLE
Do not create venv inside source root

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -89,6 +89,7 @@ runs:
         # Disable cashing on the default branch and tag builds
         enable-cache: "${{ !(github.ref_name == github.event.repository.default_branch || startsWith(github.ref, 'refs/tags/')) }}"
         activate-environment: 'true'
+        venv-path: '../.venv'
         prune-cache: 'false'
         cache-dependency-glob: |
           **/requirements/*.txt


### PR DESCRIPTION
With the default location, a `python src/manage.py compilemessages` command will also detect all .po files in the dependencies (django), which is not really necessary.

By moving it one level up, these files are not picked up when running commands in the source root.